### PR TITLE
Move depreciated operators to bottom

### DIFF
--- a/Source/Driver+Occupiable.swift
+++ b/Source/Driver+Occupiable.swift
@@ -47,6 +47,7 @@ public extension Driver where Element: Occupiable {
 
      - returns: Driver of unwrapped elements.
      */
+    @available(*, deprecated, message="https://github.com/RxSwiftCommunity/RxOptional/issues/4")
     @warn_unused_result(message="http://git.io/rxs.uo")
     public func fatalErrorOnEmpty() -> Driver<Element> {
         return self.flatMap { element -> Driver<Element> in

--- a/Source/Driver+Optional.swift
+++ b/Source/Driver+Optional.swift
@@ -17,25 +17,6 @@ public extension Driver where Element: OptionalType {
     }
 
     /**
-     Unwraps optional values and if finds nil fatalErrors.
-
-     During release builds fatalErrors are logged, behaves exactly like
-     `.filterOnNil`. Durring Debug builds continutes after logging fatalError.
-
-     - returns: Driver with unwrapped value.
-     */
-    @warn_unused_result(message="http://git.io/rxs.uo")
-    public func fatalErrorOnNil() -> Driver<Element.Wrapped> {
-        return self.flatMap { element -> Driver<Element.Wrapped> in
-            guard let value = element.value else {
-                RxOptionalFatalError(RxOptionalError.FoundNilWhileUnwrappingOptional(Element.self))
-                return Driver<Element.Wrapped>.empty()
-            }
-            return Driver<Element.Wrapped>.just(value)
-        }
-    }
-
-    /**
      Unwraps optional and replace nil values with value.
 
      - parameter valueOnNil: Value to emit when nil is found.
@@ -66,6 +47,26 @@ public extension Driver where Element: OptionalType {
         return self.flatMap { element -> Driver<Element.Wrapped> in
             guard let value = element.value else {
                 return handler()
+            }
+            return Driver<Element.Wrapped>.just(value)
+        }
+    }
+
+    /**
+     Unwraps optional values and if finds nil fatalErrors.
+
+     During release builds fatalErrors are logged, behaves exactly like
+     `.filterOnNil`. Durring Debug builds continutes after logging fatalError.
+
+     - returns: Driver with unwrapped value.
+     */
+    @available(*, deprecated, message="https://github.com/RxSwiftCommunity/RxOptional/issues/4")
+    @warn_unused_result(message="http://git.io/rxs.uo")
+    public func fatalErrorOnNil() -> Driver<Element.Wrapped> {
+        return self.flatMap { element -> Driver<Element.Wrapped> in
+            guard let value = element.value else {
+                RxOptionalFatalError(RxOptionalError.FoundNilWhileUnwrappingOptional(Element.self))
+                return Driver<Element.Wrapped>.empty()
             }
             return Driver<Element.Wrapped>.just(value)
         }

--- a/Source/Observable+Optional.swift
+++ b/Source/Observable+Optional.swift
@@ -21,27 +21,6 @@ public extension ObservableType where E: OptionalType {
     }
 
     /**
-     Unwraps optional values and if finds nil fatalErrors.
-
-     During release builds fatalErrors are logged, behaves exactly like
-     `.errorOnNil`. Durring Debug builds sends Error event
-     `RxOptionalError.FoundNilWhileUnwrappingOptional`.
-
-     - returns: Observbale of unwrapped value.
-     */
-    @available(*, deprecated, message="https://github.com/RxSwiftCommunity/RxOptional/issues/4")
-    @warn_unused_result(message="http://git.io/rxs.uo")
-    public func fatalErrorOnNil() -> Observable<E.Wrapped> {
-        return self.map { element in
-            guard let value = element.value else {
-                RxOptionalFatalError(RxOptionalError.FoundNilWhileUnwrappingOptional(E.self))
-                throw RxOptionalError.FoundNilWhileUnwrappingOptional(E.self)
-            }
-            return value
-        }
-    }
-
-    /**
      Unwraps optional and if finds nil emmits error.
 
      - parameter error: Error to emit when nil if found. Defaults to
@@ -92,6 +71,27 @@ public extension ObservableType where E: OptionalType {
                 return try handler()
             }
             return Observable<E.Wrapped>.just(value)
+        }
+    }
+
+    /**
+     Unwraps optional values and if finds nil fatalErrors.
+
+     During release builds fatalErrors are logged, behaves exactly like
+     `.errorOnNil`. Durring Debug builds sends Error event
+     `RxOptionalError.FoundNilWhileUnwrappingOptional`.
+
+     - returns: Observbale of unwrapped value.
+     */
+    @available(*, deprecated, message="https://github.com/RxSwiftCommunity/RxOptional/issues/4")
+    @warn_unused_result(message="http://git.io/rxs.uo")
+    public func fatalErrorOnNil() -> Observable<E.Wrapped> {
+        return self.map { element in
+            guard let value = element.value else {
+                RxOptionalFatalError(RxOptionalError.FoundNilWhileUnwrappingOptional(E.self))
+                throw RxOptionalError.FoundNilWhileUnwrappingOptional(E.self)
+            }
+            return value
         }
     }
 }


### PR DESCRIPTION
Add deprecation attribute to missed fatalErrorOn* operators