### PR TITLE
Version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 2.0.0
+- ** Breaking Change**: Remove `fatalErrorOn*` operators
 - ** Breaking Change**: Remove guarantees from `catchOnEmpty` operators
 
 # 1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-
+# 2.0.0
+- ** Breaking Change**: Remove guarantees from `catchOnEmpty` operators
 
 # 1.2.0
 - Add unit tests

--- a/Example/Examples.playground/Contents.swift
+++ b/Example/Examples.playground/Contents.swift
@@ -26,14 +26,16 @@ public func example(description: String, action: () -> ()) {
 example("filterNil") {
     let _ = Observable<String?>
         .of("One", nil, "Three")
-        .filterNil() // Type is now Observable<String>
+        .filterNil()
+        // Type is now Observable<String>
         .subscribe { print($0) }
 }
 
 example("replaceNilWith") {
     let _ = Observable<String?>
         .of("One", nil, "Three")
-        .replaceNilWith("Two") // Type is now Observable<String>
+        .replaceNilWith("Two")
+        // Type is now Observable<String>
         .subscribe { print($0) }
 }
 
@@ -46,6 +48,7 @@ example("errorOnNil") {
     let _ = Observable<String?>
         .of("One", nil, "Three")
         .errorOnNil()
+        // Type is now Observable<String>
         .subscribe { print($0) }
 }
 
@@ -54,7 +57,8 @@ example("catchOnNil") {
         .of("One", nil, "Three")
         .catchOnNil {
             return Observable<String>.just("A String from a new Observable")
-        }  // Type is now Observable<String>
+        }
+        // Type is now Observable<String>
         .subscribe { print($0) }
 }
 
@@ -67,7 +71,11 @@ example("filterEmpty") {
         .subscribe { print($0) }
 }
 
-//: By default errors with `RxOptionalError.EmptyOccupiable`.
+/*:
+ Unavailable on Driver
+
+ By default errors with `RxOptionalError.EmptyOccupiable`.
+ */
 example("errorOnEmpty") {
     let _ = Observable<[String]>
         .of(["Single Element"], [], ["Two", "Elements"])

--- a/Example/Examples.playground/Contents.swift
+++ b/Example/Examples.playground/Contents.swift
@@ -38,18 +38,6 @@ example("replaceNilWith") {
 }
 
 /*:
- During release builds fatalErrors are logged. Durring Debug builds
- `.fatalErrorOnNil()` sends Error event for Observables and Driver
- continutes after logging fatalError.
-*/
-example("fatalErrorOnNil") {
-    let _ = Observable<String?>
-        .of("One", nil, "Three")
-        .fatalErrorOnNil()  // Durring release fatalErrors will only be logged
-        .subscribe { print($0) }
-}
-
-/*:
  Unavailable on Driver
  
  By default errors with `RxOptionalError.FoundNilWhileUnwrappingOptional`.
@@ -76,18 +64,6 @@ example("filterEmpty") {
     let _ = Observable<[String]>
         .of(["Single Element"], [], ["Two", "Elements"])
         .filterEmpty()
-        .subscribe { print($0) }
-}
-
-/*:
- During release builds fatalErrors are logged. Durring Debug builds
- `.fatalErrorOnEmpty()` sends Error event for Observables and Driver
- continutes after logging fatalError.
-*/
-example("fatalErrorOnEmpty") {
-    let _ = Observable<[String]>
-        .of(["Single Element"], [], ["Two", "Elements"])
-        .fatalErrorOnEmpty()
         .subscribe { print($0) }
 }
 

--- a/Example/Examples.playground/Contents.swift
+++ b/Example/Examples.playground/Contents.swift
@@ -8,7 +8,7 @@ Steps to Run
 - Run `pod install` in Example directory
 - Select RxOptional Examples Target
 - Build
-- Show Debug Area (cmd+shit+Y)
+- Show Debug Area (cmd+shift+Y)
 - Click blue play button in Debug Area
 
 */
@@ -99,11 +99,6 @@ example("errorOnEmpty") {
         .subscribe { print($0) }
 }
 
-/*:
- `.catchOnEmpty` guarantees that the hander function returns a Observable or Driver with
- non-empty elements by calling `.errorOnEmpty` or `.fatalErrorOnEmpty`
- respectfully.
-*/
 example("catchOnEmpty") {
     let _ = Observable<[String]>
         .of(["Single Element"], [], ["Two", "Elements"])

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ All operators are available on Driver as well unless otherwise marked.
 ```swift
 Observable<String?>
     .of("One", nil, "Three")
-    .filterNil() // Type is now Observable<String>
+    .filterNil()
+    // Type is now Observable<String>
     .subscribe { print($0) }
 ```
 ```text
@@ -31,7 +32,8 @@ Completed
 ```swift
 Observable<String?>
     .of("One", nil, "Three")
-    .replaceNilWith("Two") // Type is now Observable<String>
+    .replaceNilWith("Two")
+    // Type is now Observable<String>
     .subscribe { print($0) }
 ```
 ```text
@@ -42,12 +44,14 @@ Completed
 ```
 
 ##### errorOnNil
-Unavailable on Driver. By default errors with
-`RxOptionalError.FoundNilWhileUnwrappingOptional`.
+Unavailable on Driver.
+
+By default errors with `RxOptionalError.FoundNilWhileUnwrappingOptional`.
 ```swift
 Observable<String?>
     .of("One", nil, "Three")
     .errorOnNil()
+    // Type is now Observable<String>
     .subscribe { print($0) }
 ```
 ```text
@@ -61,7 +65,8 @@ Observable<String?>
     .of("One", nil, "Three")
     .catchOnNil {
         return Observable<String>.just("A String from a new Observable")
-    } // Type is now Observable<String>
+    }
+    // Type is now Observable<String>
     .subscribe { print($0) }
 ```
 ```text
@@ -98,6 +103,8 @@ Completed
 ```
 
 ##### errorOnEmpty
+Unavailable on Driver.
+
 By default errors with `RxOptionalError.EmptyOccupiable`.
 ```swift
 Observable<[String]>
@@ -132,7 +139,7 @@ Completed
 - Select RxOptional Examples Target
 - Build
 - Open Examples.playground
-- Show Debug Area (cmd+shit+Y)
+- Show Debug Area (cmd+shift+Y)
 - Click blue play button in Debug Area
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -143,9 +143,6 @@ Error(Empty occupiable of type <Array<String>>)
 ```
 
 ##### catchOnEmpty
-`.catchOnEmpty` guarantees that the hander function returns a Observable or Driver with
-non-empty elements by calling `.errorOnEmpty` or `.fatalErrorOnEmpty`
-respectfully.
 ```swift
 Observable<[String]>
     .of(["Single Element"], [], ["Two", "Elements"])

--- a/README.md
+++ b/README.md
@@ -41,22 +41,6 @@ Next(Three)
 Completed
 ```
 
-##### fatalErrorOnNil
-During release builds fatalErrors are logged. Durring Debug builds
-`.fatalErrorOnNil()` sends Error event for Observables and Driver
-continutes after logging fatalError.
-```swift
-Observable<String?>
-    .of("One", nil, "Three")
-    .fatalErrorOnNil()
-    .subscribe { print($0) }
-```
-```text
-Next(One)
-fatal Error: Found nil while trying to unwrap type <Optional<String>>
-Error(Found nil while trying to unwrap type <Optional<String>>)
-```
-
 ##### errorOnNil
 Unavailable on Driver. By default errors with
 `RxOptionalError.FoundNilWhileUnwrappingOptional`.
@@ -111,22 +95,6 @@ Observable<[String]>
 Next(["Single Element"])
 Next(["Two", "Elements"])
 Completed
-```
-
-##### fatalErrorOnEmpty
-During release builds fatalErrors are logged. Durring Debug builds
-`.fatalErrorOnEmpty()` sends Error event for Observables and Driver
-continutes after logging fatalError.
-```swift
-Observable<[String]>
-    .of(["Single Element"], [], ["Two", "Elements"])
-    .fatalErrorOnEmpty()
-    .subscribe { print($0) }
-```
-```text
-Next(["Single Element"])
-fatal Error: Empty occupiable of type <Array<String>>
-Error(Empty occupiable of type <Array<String>>)
 ```
 
 ##### errorOnEmpty

--- a/RxOptional.podspec
+++ b/RxOptional.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name        = 'RxOptional'
-  s.version     = '1.2.0'
+  s.version     = '2.0.0'
   s.summary     = 'RxSwift extentions for Swift optionals and Occupiable types'
 
   s.description = <<-DESC

--- a/Source/Driver+Occupiable.swift
+++ b/Source/Driver+Occupiable.swift
@@ -35,24 +35,4 @@ public extension Driver where Element: Occupiable {
             return Driver<Element>.just(element)
         }
     }
-
-    /**
-     Unwraps optional values and if finds nil fatalErrors.
-
-     During release builds fatalErrors are logged. Durring Debug builds
-     continutes after logging fatalError.
-
-     - returns: Driver of unwrapped elements.
-     */
-    @available(*, deprecated, message="https://github.com/RxSwiftCommunity/RxOptional/issues/4")
-    @warn_unused_result(message="http://git.io/rxs.uo")
-    public func fatalErrorOnEmpty() -> Driver<Element> {
-        return self.flatMap { element -> Driver<Element> in
-            guard element.isNotEmpty else {
-                RxOptionalFatalError(RxOptionalError.EmptyOccupiable(Element.self))
-                return Driver.empty()
-            }
-            return Driver<Element>.just(element)
-        }
-    }
 }

--- a/Source/Driver+Occupiable.swift
+++ b/Source/Driver+Occupiable.swift
@@ -47,6 +47,7 @@ public extension Driver where Element: Occupiable {
 
      - returns: Driver of unwrapped elements.
      */
+    @available(*, deprecated, message="https://github.com/RxSwiftCommunity/RxOptional/issues/4")
     @warn_unused_result(message="http://git.io/rxs.uo")
     public func fatalErrorOnEmpty() -> Driver<Element> {
         return self.flatMap { element -> Driver<Element> in

--- a/Source/Driver+Occupiable.swift
+++ b/Source/Driver+Occupiable.swift
@@ -21,8 +21,6 @@ public extension Driver where Element: Occupiable {
      When empty uses handler to call another Driver otherwise passes elemets.
 
      - parameter handler: Empty handler function, producing another Driver.
-     Guarantees non-empty by fatalErroring when handler returns an Driver
-     with empty elements.
 
      - returns: Driver containing the source sequence's elements,
      followed by the elements produced by the handler's resulting observable
@@ -33,7 +31,6 @@ public extension Driver where Element: Occupiable {
         return self.flatMap { element -> Driver<Element> in
             guard element.isNotEmpty else {
                 return handler()
-                    .fatalErrorOnEmpty()
             }
             return Driver<Element>.just(element)
         }

--- a/Source/Driver+Optional.swift
+++ b/Source/Driver+Optional.swift
@@ -17,25 +17,6 @@ public extension Driver where Element: OptionalType {
     }
 
     /**
-     Unwraps optional values and if finds nil fatalErrors.
-
-     During release builds fatalErrors are logged, behaves exactly like
-     `.filterOnNil`. Durring Debug builds continutes after logging fatalError.
-
-     - returns: Driver with unwrapped value.
-     */
-    @warn_unused_result(message="http://git.io/rxs.uo")
-    public func fatalErrorOnNil() -> Driver<Element.Wrapped> {
-        return self.flatMap { element -> Driver<Element.Wrapped> in
-            guard let value = element.value else {
-                RxOptionalFatalError(RxOptionalError.FoundNilWhileUnwrappingOptional(Element.self))
-                return Driver<Element.Wrapped>.empty()
-            }
-            return Driver<Element.Wrapped>.just(value)
-        }
-    }
-
-    /**
      Unwraps optional and replace nil values with value.
 
      - parameter valueOnNil: Value to emit when nil is found.
@@ -66,6 +47,26 @@ public extension Driver where Element: OptionalType {
         return self.flatMap { element -> Driver<Element.Wrapped> in
             guard let value = element.value else {
                 return handler()
+            }
+            return Driver<Element.Wrapped>.just(value)
+        }
+    }
+
+    /**
+     Unwraps optional values and if finds nil fatalErrors.
+
+     During release builds fatalErrors are logged, behaves exactly like
+     `.filterOnNil`. Durring Debug builds continutes after logging fatalError.
+
+     - returns: Driver with unwrapped value.
+     */
+    @available(*, deprecated, message="https://github.com/RxSwiftCommunity/RxOptional/issues/4")
+    @warn_unused_result(message="http://git.io/rxs.uo")
+    public func fatalErrorOnNil() -> Driver<Element.Wrapped> {
+        return self.flatMap { element -> Driver<Element.Wrapped> in
+            guard let value = element.value else {
+                RxOptionalFatalError(RxOptionalError.FoundNilWhileUnwrappingOptional(Element.self))
+                return Driver<Element.Wrapped>.empty()
             }
             return Driver<Element.Wrapped>.just(value)
         }

--- a/Source/Driver+Optional.swift
+++ b/Source/Driver+Optional.swift
@@ -51,24 +51,4 @@ public extension Driver where Element: OptionalType {
             return Driver<Element.Wrapped>.just(value)
         }
     }
-
-    /**
-     Unwraps optional values and if finds nil fatalErrors.
-
-     During release builds fatalErrors are logged, behaves exactly like
-     `.filterOnNil`. Durring Debug builds continutes after logging fatalError.
-
-     - returns: Driver with unwrapped value.
-     */
-    @available(*, deprecated, message="https://github.com/RxSwiftCommunity/RxOptional/issues/4")
-    @warn_unused_result(message="http://git.io/rxs.uo")
-    public func fatalErrorOnNil() -> Driver<Element.Wrapped> {
-        return self.flatMap { element -> Driver<Element.Wrapped> in
-            guard let value = element.value else {
-                RxOptionalFatalError(RxOptionalError.FoundNilWhileUnwrappingOptional(Element.self))
-                return Driver<Element.Wrapped>.empty()
-            }
-            return Driver<Element.Wrapped>.just(value)
-        }
-    }
 }

--- a/Source/Observable+Occupiable.swift
+++ b/Source/Observable+Occupiable.swift
@@ -21,8 +21,6 @@ public extension ObservableType where E: Occupiable {
      When empty uses handler to call another Observbale otherwise passes elemets.
 
      - parameter handler: Empty handler function, producing another observable.
-     Guarantees non-empty by throwing RxOptionalError.EmptyOccupiable is handler
-     returns an Observable with empty elements.
 
      - returns: An observable sequence containing the source sequence's elements,
      followed by the elements produced by the handler's resulting observable
@@ -33,7 +31,6 @@ public extension ObservableType where E: Occupiable {
         return self.flatMap { element -> Observable<E> in
             guard element.isNotEmpty else {
                 return try handler()
-                    .errorOnEmpty()
             }
             return Observable<E>.just(element)
         }

--- a/Source/Observable+Occupiable.swift
+++ b/Source/Observable+Occupiable.swift
@@ -54,25 +54,4 @@ public extension ObservableType where E: Occupiable {
             return element
         }
     }
-
-    /**
-     Unwraps optional values and if finds nil fatalErrors.
-
-     During release builds fatalErrors are logged, behaves exactly like
-     `.errorOnError`. Durring Debug builds sends Error event
-     `RxOptionalError.EmptyOccupiable`.
-
-     - returns: Observbale of unwrapped value
-     */
-    @available(*, deprecated, message="https://github.com/RxSwiftCommunity/RxOptional/issues/4")
-    @warn_unused_result(message="http://git.io/rxs.uo")
-    public func fatalErrorOnEmpty() -> Observable<E> {
-        return self.map { element in
-            guard element.isNotEmpty else {
-                RxOptionalFatalError(RxOptionalError.EmptyOccupiable(E.self))
-                throw RxOptionalError.EmptyOccupiable(E.self)
-            }
-            return element
-        }
-    }
 }

--- a/Source/Observable+Optional.swift
+++ b/Source/Observable+Optional.swift
@@ -21,27 +21,6 @@ public extension ObservableType where E: OptionalType {
     }
 
     /**
-     Unwraps optional values and if finds nil fatalErrors.
-
-     During release builds fatalErrors are logged, behaves exactly like
-     `.errorOnNil`. Durring Debug builds sends Error event
-     `RxOptionalError.FoundNilWhileUnwrappingOptional`.
-
-     - returns: Observbale of unwrapped value.
-     */
-    @available(*, deprecated, message="https://github.com/RxSwiftCommunity/RxOptional/issues/4")
-    @warn_unused_result(message="http://git.io/rxs.uo")
-    public func fatalErrorOnNil() -> Observable<E.Wrapped> {
-        return self.map { element in
-            guard let value = element.value else {
-                RxOptionalFatalError(RxOptionalError.FoundNilWhileUnwrappingOptional(E.self))
-                throw RxOptionalError.FoundNilWhileUnwrappingOptional(E.self)
-            }
-            return value
-        }
-    }
-
-    /**
      Unwraps optional and if finds nil emmits error.
 
      - parameter error: Error to emit when nil if found. Defaults to
@@ -92,6 +71,27 @@ public extension ObservableType where E: OptionalType {
                 return try handler()
             }
             return Observable<E.Wrapped>.just(value)
+        }
+    }
+
+    /**
+     Unwraps optional values and if finds nil fatalErrors.
+
+     During release builds fatalErrors are logged, behaves exactly like
+     `.errorOnNil`. Durring Debug builds sends Error event
+     `RxOptionalError.FoundNilWhileUnwrappingOptional`.
+
+     - returns: Observbale of unwrapped value.
+     */
+    @available(*, deprecated, message="https://github.com/RxSwiftCommunity/RxOptional/issues/4")
+    @warn_unused_result(message="http://git.io/rxs.uo")
+    public func fatalErrorOnNil() -> Observable<E.Wrapped> {
+        return self.map { element in
+            guard let value = element.value else {
+                RxOptionalFatalError(RxOptionalError.FoundNilWhileUnwrappingOptional(E.self))
+                throw RxOptionalError.FoundNilWhileUnwrappingOptional(E.self)
+            }
+            return value
         }
     }
 }

--- a/Source/Observable+Optional.swift
+++ b/Source/Observable+Optional.swift
@@ -73,25 +73,4 @@ public extension ObservableType where E: OptionalType {
             return Observable<E.Wrapped>.just(value)
         }
     }
-
-    /**
-     Unwraps optional values and if finds nil fatalErrors.
-
-     During release builds fatalErrors are logged, behaves exactly like
-     `.errorOnNil`. Durring Debug builds sends Error event
-     `RxOptionalError.FoundNilWhileUnwrappingOptional`.
-
-     - returns: Observbale of unwrapped value.
-     */
-    @available(*, deprecated, message="https://github.com/RxSwiftCommunity/RxOptional/issues/4")
-    @warn_unused_result(message="http://git.io/rxs.uo")
-    public func fatalErrorOnNil() -> Observable<E.Wrapped> {
-        return self.map { element in
-            guard let value = element.value else {
-                RxOptionalFatalError(RxOptionalError.FoundNilWhileUnwrappingOptional(E.self))
-                throw RxOptionalError.FoundNilWhileUnwrappingOptional(E.self)
-            }
-            return value
-        }
-    }
 }

--- a/Source/RxOptionalError.swift
+++ b/Source/RxOptionalError.swift
@@ -13,17 +13,3 @@ public enum RxOptionalError: ErrorType, CustomStringConvertible {
         }
     }
 }
-
-/// fatalError only in Debug build
-func RxOptionalFatalError(error: ErrorType) {
-    #if DEBUG
-        rxfatalError(error)
-    #else
-        print("fatalError: \(error)")
-    #endif
-}
-
-/// Overload fatalError to accept ErrorType
-@noreturn func fatalError(error: ErrorType) {
-    fatalError("\(error)")
-}

--- a/Tests/OptionalOperatorsTests.swift
+++ b/Tests/OptionalOperatorsTests.swift
@@ -49,26 +49,6 @@ class OptionalOperatorsSpec: QuickSpec {
             }
         }
 
-        describe("fatalErrorOnNil") {
-            context("Observable") {
-                it("unwraps the optional") {
-                    // Check on compile
-                    let _: Observable<Int> = Observable<Int?>
-                        .just(nil)
-                        .fatalErrorOnNil()
-                }
-            }
-
-            context("Driver") {
-                it("unwraps the optional") {
-                    // Check on compile
-                    let _: Driver<Int> = Driver<Int?>
-                        .just(nil)
-                        .fatalErrorOnNil()
-                }
-            }
-        }
-
         describe("Error On Nil") {
             context("Observable") {
                 it("unwraps the optional") {


### PR DESCRIPTION
## Breaking changes:
- Remove guarantees from `catchOnEmpty` operators
- Remove `fatalErrroOn*` operators #4 