### PR TITLE
Swift 2.2 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@
 language: objective-c
 cache: cocoapods
 podfile: Example/Podfile
-osx_image: xcode7.2
+osx_image: xcode7.3
 xcode_workspace: Example/RxOptional.xcworkspace
 xcode_scheme: RxOptional Examples
-xcode_sdk: iphonesimulator9.2
+xcode_sdk: iphonesimulator9.3

--- a/Source/OptionalType.swift
+++ b/Source/OptionalType.swift
@@ -4,7 +4,7 @@ import Foundation
 // Credit to Artsy and @ashfurrow
 
 public protocol OptionalType {
-    typealias Wrapped
+    associatedtype Wrapped
     var value: Wrapped? { get }
 }
 


### PR DESCRIPTION
There's only one very minor change: `typelias` → `associatedtype`

You'll probably want to bump the point release, although given this is going to leave Xcode 7.2 and prior users in the dust, SemVer probably dictates that this PR constitutes a major release (for a one word change :stuck_out_tongue_closed_eyes:).