### PR TITLE
Fix carthage build

### DIFF
--- a/RxOptional.xcodeproj/xcshareddata/xcschemes/RxOptional iOS.xcscheme
+++ b/RxOptional.xcodeproj/xcshareddata/xcschemes/RxOptional iOS.xcscheme
@@ -22,7 +22,7 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">

--- a/RxOptional.xcodeproj/xcshareddata/xcschemes/RxOptional macOS.xcscheme
+++ b/RxOptional.xcodeproj/xcshareddata/xcschemes/RxOptional macOS.xcscheme
@@ -22,7 +22,7 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">

--- a/RxOptional.xcodeproj/xcshareddata/xcschemes/RxOptional tvOS.xcscheme
+++ b/RxOptional.xcodeproj/xcshareddata/xcschemes/RxOptional tvOS.xcscheme
@@ -22,7 +22,7 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">

--- a/RxOptional.xcodeproj/xcshareddata/xcschemes/RxOptional watchOS.xcscheme
+++ b/RxOptional.xcodeproj/xcshareddata/xcschemes/RxOptional watchOS.xcscheme
@@ -22,7 +22,7 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">


### PR DESCRIPTION
Fix Carthage build by setting buildForRunning=NO for test target. This prevent Carthage to build
test target, which include private dependencies Quick that cause build error.

Ref: https://github.com/Carthage/Carthage/issues/515