### PR TITLE
Bump Cartfile dependency on RxSwift to 3.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.2
+
+- RxSwift 3.0.0-rc.1 support for Carthage.
+
 # 3.1.1
 
 - Improved Carthage support.

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "3.0.0-beta.2"
+github "ReactiveX/RxSwift" "3.0.0-rc.1"

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,1 @@
-github "Quick/Quick" "swift-3.0"
-github "Quick/Nimble" "master"
+github "Quick/Quick"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,2 @@
-github "Quick/Nimble" "db706fc1d7130f6ac96c56aaf0e635fa3217fe57"
-github "Quick/Quick" "1503fb019d72417d5d6e4fbebdbaa03c9e4a125f"
-github "ReactiveX/RxSwift" "3.0.0-beta.1"
+github "Quick/Quick" "v0.10.0"
+github "ReactiveX/RxSwift" "3.0.0-rc.1"

--- a/RxOptional.podspec
+++ b/RxOptional.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name        = 'RxOptional'
-  s.version     = '3.1.1'
+  s.version     = '3.1.2'
   s.summary     = 'RxSwift extensions for Swift optionals and Occupiable types'
 
   s.description = <<-DESC


### PR DESCRIPTION
Until the RxSwift tag is bumped to `3.0.0`, Carthage is (arguably correctly) ordering the RxSwift `3.0.0.alpha*` tag before `3.0.0-beta*` and `3.0.0-rc*`. 

With each new RxSwift release, it's necessary to bump the specific listed version in this project's Cartfile. 

Hopefully when RxSwift hits `3.0.0`, we can just drop back to `~> 3.0` in the Cartfile.