### PR TITLE
Bump Cartfile, Podspec and changelog for RxSwift 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.3
+
+- RxSwift 3.0.0 support for Carthage.
+
 # 3.1.2
 
 - RxSwift 3.0.0-rc.1 support for Carthage.

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "3.0.0-rc.1"
+github "ReactiveX/RxSwift" ~> 3.0

--- a/RxOptional.podspec
+++ b/RxOptional.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name        = 'RxOptional'
-  s.version     = '3.1.2'
+  s.version     = '3.1.3'
   s.summary     = 'RxSwift extensions for Swift optionals and Occupiable types'
 
   s.description = <<-DESC


### PR DESCRIPTION
This should be the last time we need to do this. Carthage will correctly parse future RxSwift release tags (so long as nobody on the RxSwift project ballses up the SemVer format in a future tag).