### PR TITLE
Adds filterNilKeepOptional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Adds `filterNilKeepOptional`. 
+
 # 3.1.3
 
 - RxSwift 3.0.0 support for Carthage.

--- a/Source/Observable+Optional.swift
+++ b/Source/Observable+Optional.swift
@@ -20,6 +20,20 @@ public extension ObservableType where E: OptionalType {
         }
     }
 
+    /** 
+    
+    Filters out `nil` elements. Similar to `filterNil`, but keeps the elements of the observable
+    wrapped in Optionals. This is often useful for binding to a UIBindingObserver with an optional type.
+
+    - returns: `Observable` of source `Observable`'s elements, with `nil` elements filtered out.
+    */
+
+    public func filterNilKeepOptional() -> Observable<E> {
+        return self.filter { element -> Bool in
+            return element.value != nil
+        }
+    }
+
     /**
      Throws an error if the source `Observable` contains an empty element; otherwise returns original source `Observable` of non-empty elements.
 

--- a/Test/OptionalOperatorsTests.swift
+++ b/Test/OptionalOperatorsTests.swift
@@ -22,7 +22,19 @@ class OptionalOperatorsSpec: QuickSpec {
                         .toArray()
                         .subscribe(onNext: {
                             expect($0).to(equal([1, 3, 4]))
-                        })                       
+                        })
+                        .dispose()
+                }
+
+
+                it("filters nil values and keeps types") {
+                    Observable<Int?>
+                        .of(1, nil, 3, 4)
+                        .filterNilKeepOptional()
+                        .toArray()
+                        .subscribe(onNext: {
+                            expect($0).to(equal([1, 3, 4]))
+                        })
                         .dispose()
                 }
             }


### PR DESCRIPTION
I was cleaning up issues, came across [this one](https://github.com/artsy/eidolon/issues/587) to migrate Eidolon (the inspiration for RxOptional) to use RxOptional. Found one method I had added, thought I'd add it here too. 