### PR TITLE
Support other kinds of SharedSequence implementations, most importantly - Signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+- Loosen generic constraints to work with any SharingStrategy, instead of just Driver.
+
 # 3.4.0
 
 - Swift 4.1 compatibility
@@ -10,7 +12,7 @@
 
 # 3.2.0
 
-- Adds `filterNilKeepOptional`. 
+- Adds `filterNilKeepOptional`.
 
 # 3.1.3
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v7.0.2"
-github "Quick/Quick" "v1.2.0"
-github "ReactiveX/RxSwift" "4.0.0"
+github "Quick/Nimble" "v7.1.2"
+github "Quick/Quick" "v1.3.0"
+github "ReactiveX/RxSwift" "4.2.0"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ RxSwift extensions for Swift optionals and "Occupiable" types.
 
 ## Usage
 
-All operators are also available on `Driver`, unless otherwise noted.
+All operators are also available on `Driver` and `Signal`, unless otherwise noted.
 
 ### Optional Operators
 

--- a/RxOptional.xcodeproj/project.pbxproj
+++ b/RxOptional.xcodeproj/project.pbxproj
@@ -22,12 +22,12 @@
 		4B5983A31D9030B300409FC8 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B5983A11D9030B300409FC8 /* RxSwift.framework */; };
 		4B5983A61D9030C100409FC8 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B5983A41D9030C100409FC8 /* RxCocoa.framework */; };
 		4B5983A71D9030C100409FC8 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B5983A51D9030C100409FC8 /* RxSwift.framework */; };
-		4B5983C21D9035A500409FC8 /* Driver+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B81D9035A500409FC8 /* Driver+Occupiable.swift */; };
-		4B5983C31D9035A500409FC8 /* Driver+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B81D9035A500409FC8 /* Driver+Occupiable.swift */; };
-		4B5983C41D9035A500409FC8 /* Driver+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B81D9035A500409FC8 /* Driver+Occupiable.swift */; };
-		4B5983C61D9035A500409FC8 /* Driver+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B91D9035A500409FC8 /* Driver+Optional.swift */; };
-		4B5983C71D9035A500409FC8 /* Driver+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B91D9035A500409FC8 /* Driver+Optional.swift */; };
-		4B5983C81D9035A500409FC8 /* Driver+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B91D9035A500409FC8 /* Driver+Optional.swift */; };
+		4B5983C21D9035A500409FC8 /* SharedSequence+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B81D9035A500409FC8 /* SharedSequence+Occupiable.swift */; };
+		4B5983C31D9035A500409FC8 /* SharedSequence+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B81D9035A500409FC8 /* SharedSequence+Occupiable.swift */; };
+		4B5983C41D9035A500409FC8 /* SharedSequence+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B81D9035A500409FC8 /* SharedSequence+Occupiable.swift */; };
+		4B5983C61D9035A500409FC8 /* SharedSequence+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B91D9035A500409FC8 /* SharedSequence+Optional.swift */; };
+		4B5983C71D9035A500409FC8 /* SharedSequence+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B91D9035A500409FC8 /* SharedSequence+Optional.swift */; };
+		4B5983C81D9035A500409FC8 /* SharedSequence+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B91D9035A500409FC8 /* SharedSequence+Optional.swift */; };
 		4B5983CA1D9035A500409FC8 /* Observable+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983BA1D9035A500409FC8 /* Observable+Occupiable.swift */; };
 		4B5983CB1D9035A500409FC8 /* Observable+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983BA1D9035A500409FC8 /* Observable+Occupiable.swift */; };
 		4B5983CC1D9035A500409FC8 /* Observable+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983BA1D9035A500409FC8 /* Observable+Occupiable.swift */; };
@@ -60,8 +60,8 @@
 		8482735E1DF9C9840083191B /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B5983A91D9030C800409FC8 /* RxSwift.framework */; };
 		8482735F1DF9C9840083191B /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B5983A81D9030C800409FC8 /* RxCocoa.framework */; };
 		848273611DF9C9DC0083191B /* RxOptional.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B5983C11D9035A500409FC8 /* RxOptional.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		848273651DF9CE3C0083191B /* Driver+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B81D9035A500409FC8 /* Driver+Occupiable.swift */; };
-		848273661DF9CE3C0083191B /* Driver+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B91D9035A500409FC8 /* Driver+Optional.swift */; };
+		848273651DF9CE3C0083191B /* SharedSequence+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B81D9035A500409FC8 /* SharedSequence+Occupiable.swift */; };
+		848273661DF9CE3C0083191B /* SharedSequence+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983B91D9035A500409FC8 /* SharedSequence+Optional.swift */; };
 		848273671DF9CE3C0083191B /* Observable+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983BA1D9035A500409FC8 /* Observable+Occupiable.swift */; };
 		848273681DF9CE3C0083191B /* Observable+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983BB1D9035A500409FC8 /* Observable+Optional.swift */; };
 		848273691DF9CE3C0083191B /* Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983BC1D9035A500409FC8 /* Occupiable.swift */; };
@@ -123,8 +123,8 @@
 		4B5983A51D9030C100409FC8 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/Mac/RxSwift.framework; sourceTree = "<group>"; };
 		4B5983A81D9030C800409FC8 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Build/tvOS/RxCocoa.framework; sourceTree = "<group>"; };
 		4B5983A91D9030C800409FC8 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/tvOS/RxSwift.framework; sourceTree = "<group>"; };
-		4B5983B81D9035A500409FC8 /* Driver+Occupiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Driver+Occupiable.swift"; sourceTree = "<group>"; };
-		4B5983B91D9035A500409FC8 /* Driver+Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Driver+Optional.swift"; sourceTree = "<group>"; };
+		4B5983B81D9035A500409FC8 /* SharedSequence+Occupiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SharedSequence+Occupiable.swift"; sourceTree = "<group>"; };
+		4B5983B91D9035A500409FC8 /* SharedSequence+Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SharedSequence+Optional.swift"; sourceTree = "<group>"; };
 		4B5983BA1D9035A500409FC8 /* Observable+Occupiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+Occupiable.swift"; sourceTree = "<group>"; };
 		4B5983BB1D9035A500409FC8 /* Observable+Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+Optional.swift"; sourceTree = "<group>"; };
 		4B5983BC1D9035A500409FC8 /* Occupiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Occupiable.swift; sourceTree = "<group>"; };
@@ -268,8 +268,8 @@
 		4B5983B71D9035A500409FC8 /* Source */ = {
 			isa = PBXGroup;
 			children = (
-				4B5983B81D9035A500409FC8 /* Driver+Occupiable.swift */,
-				4B5983B91D9035A500409FC8 /* Driver+Optional.swift */,
+				4B5983B81D9035A500409FC8 /* SharedSequence+Occupiable.swift */,
+				4B5983B91D9035A500409FC8 /* SharedSequence+Optional.swift */,
 				4B5983BA1D9035A500409FC8 /* Observable+Occupiable.swift */,
 				4B5983BB1D9035A500409FC8 /* Observable+Optional.swift */,
 				4B5983BC1D9035A500409FC8 /* Occupiable.swift */,
@@ -610,8 +610,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4B5983C61D9035A500409FC8 /* Driver+Optional.swift in Sources */,
-				4B5983C21D9035A500409FC8 /* Driver+Occupiable.swift in Sources */,
+				4B5983C61D9035A500409FC8 /* SharedSequence+Optional.swift in Sources */,
+				4B5983C21D9035A500409FC8 /* SharedSequence+Occupiable.swift in Sources */,
 				4B5983D21D9035A500409FC8 /* Occupiable.swift in Sources */,
 				4B5983DA1D9035A500409FC8 /* RxOptionalError.swift in Sources */,
 				4B5983CA1D9035A500409FC8 /* Observable+Occupiable.swift in Sources */,
@@ -633,8 +633,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4B5983C71D9035A500409FC8 /* Driver+Optional.swift in Sources */,
-				4B5983C31D9035A500409FC8 /* Driver+Occupiable.swift in Sources */,
+				4B5983C71D9035A500409FC8 /* SharedSequence+Optional.swift in Sources */,
+				4B5983C31D9035A500409FC8 /* SharedSequence+Occupiable.swift in Sources */,
 				4B5983D31D9035A500409FC8 /* Occupiable.swift in Sources */,
 				4B5983DB1D9035A500409FC8 /* RxOptionalError.swift in Sources */,
 				4B5983CB1D9035A500409FC8 /* Observable+Occupiable.swift in Sources */,
@@ -647,8 +647,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4B5983C81D9035A500409FC8 /* Driver+Optional.swift in Sources */,
-				4B5983C41D9035A500409FC8 /* Driver+Occupiable.swift in Sources */,
+				4B5983C81D9035A500409FC8 /* SharedSequence+Optional.swift in Sources */,
+				4B5983C41D9035A500409FC8 /* SharedSequence+Occupiable.swift in Sources */,
 				4B5983D41D9035A500409FC8 /* Occupiable.swift in Sources */,
 				4B5983DC1D9035A500409FC8 /* RxOptionalError.swift in Sources */,
 				4B5983CC1D9035A500409FC8 /* Observable+Occupiable.swift in Sources */,
@@ -690,11 +690,11 @@
 			files = (
 				848273691DF9CE3C0083191B /* Occupiable.swift in Sources */,
 				848273671DF9CE3C0083191B /* Observable+Occupiable.swift in Sources */,
-				848273651DF9CE3C0083191B /* Driver+Occupiable.swift in Sources */,
+				848273651DF9CE3C0083191B /* SharedSequence+Occupiable.swift in Sources */,
 				8482736A1DF9CE3C0083191B /* OptionalType.swift in Sources */,
 				8482736B1DF9CE3C0083191B /* RxOptionalError.swift in Sources */,
 				848273681DF9CE3C0083191B /* Observable+Optional.swift in Sources */,
-				848273661DF9CE3C0083191B /* Driver+Optional.swift in Sources */,
+				848273661DF9CE3C0083191B /* SharedSequence+Optional.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/SharedSequence+Occupiable.swift
+++ b/Source/SharedSequence+Occupiable.swift
@@ -1,19 +1,19 @@
 import Foundation
 import RxCocoa
 
-public extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingStrategy, E: Occupiable {
+public extension SharedSequenceConvertibleType where E: Occupiable {
     /**
      Filters out empty elements.
 
      - returns: `Driver` of source `Driver`'s elements, with empty elements filtered out.
      */
     
-    public func filterEmpty() -> Driver<E> {
-        return self.flatMap { element -> Driver<E> in
+    public func filterEmpty() -> SharedSequence<SharingStrategy,E> {
+        return flatMap { element -> SharedSequence<SharingStrategy,E> in
             guard element.isNotEmpty else {
-                return Driver<E>.empty()
+                return SharedSequence<SharingStrategy,E>.empty()
             }
-            return Driver<E>.just(element)
+            return SharedSequence<SharingStrategy,E>.just(element)
         }
     }
 
@@ -25,12 +25,12 @@ public extension SharedSequenceConvertibleType where SharingStrategy == DriverSh
      - returns: `Driver` of the source `Driver`'s elements, with empty elements replaced by the handler's returned non-empty elements.
      */
     
-    public func catchOnEmpty(_ handler: @escaping () -> Driver<E>) -> Driver<E> {
-        return self.flatMap { element -> Driver<E> in
+    public func catchOnEmpty(_ handler: @escaping () -> SharedSequence<SharingStrategy,E>) -> SharedSequence<SharingStrategy,E> {
+        return flatMap { element -> SharedSequence<SharingStrategy,E> in
             guard element.isNotEmpty else {
                 return handler()
             }
-            return Driver<E>.just(element)
+            return SharedSequence<SharingStrategy,E>.just(element)
         }
     }
 }

--- a/Source/SharedSequence+Optional.swift
+++ b/Source/SharedSequence+Optional.swift
@@ -1,18 +1,18 @@
 import RxCocoa
 
-public extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingStrategy, E: OptionalType {
+public extension SharedSequenceConvertibleType where E: OptionalType {
     /**
      Unwraps and filters out `nil` elements.
 
      - returns: `Driver` of source `Driver`'s elements, with `nil` elements filtered out.
      */
     
-    public func filterNil() -> Driver<E.Wrapped> {
-        return self.flatMap { element -> Driver<E.Wrapped> in
+    public func filterNil() -> SharedSequence<SharingStrategy,E.Wrapped> {
+        return flatMap { element -> SharedSequence<SharingStrategy,E.Wrapped> in
             guard let value = element.value else {
-                return Driver<E.Wrapped>.empty()
+                return SharedSequence<SharingStrategy,E.Wrapped>.empty()
             }
-            return Driver<E.Wrapped>.just(value)
+            return SharedSequence<SharingStrategy,E.Wrapped>.just(value)
         }
     }
 
@@ -24,8 +24,8 @@ public extension SharedSequenceConvertibleType where SharingStrategy == DriverSh
      - returns: `Driver` of the source `Driver`'s unwrapped elements, with `nil` elements replaced by `valueOnNil`.
      */
     
-    public func replaceNilWith(_ valueOnNil: E.Wrapped) -> Driver<E.Wrapped> {
-        return self.map { element -> E.Wrapped in
+    public func replaceNilWith(_ valueOnNil: E.Wrapped) -> SharedSequence<SharingStrategy,E.Wrapped> {
+        return map { element -> E.Wrapped in
             guard let value = element.value else {
                 return valueOnNil
             }
@@ -41,18 +41,18 @@ public extension SharedSequenceConvertibleType where SharingStrategy == DriverSh
      - returns: `Driver` of the source `Driver`'s unwrapped elements, with `nil` elements replaced by the handler's returned non-`nil` elements.
      */
     
-    public func catchOnNil(_ handler: @escaping () -> Driver<E.Wrapped>) -> Driver<E.Wrapped> {
-        return self.flatMap { element -> Driver<E.Wrapped> in
+    public func catchOnNil(_ handler: @escaping () -> SharedSequence<SharingStrategy,E.Wrapped>) -> SharedSequence<SharingStrategy,E.Wrapped> {
+        return flatMap { element -> SharedSequence<SharingStrategy,E.Wrapped> in
             guard let value = element.value else {
                 return handler()
             }
-            return Driver<E.Wrapped>.just(value)
+            return SharedSequence<SharingStrategy,E.Wrapped>.just(value)
         }
     }
 }
 
 #if !swift(>=3.3) || (swift(>=4.0) && !swift(>=4.1))
-public extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingStrategy, E: OptionalType, E.Wrapped: Equatable {
+public extension SharedSequenceConvertibleType where E: OptionalType, E.Wrapped: Equatable {
     /**
      Returns an observable sequence that contains only distinct contiguous elements according to equality operator.
      
@@ -61,7 +61,7 @@ public extension SharedSequenceConvertibleType where SharingStrategy == DriverSh
      - returns: An observable sequence only containing the distinct contiguous elements, based on equality operator, from the source sequence.
      */
     
-    public func distinctUntilChanged() -> Driver<E> {
+    public func distinctUntilChanged() -> SharedSequence<SharingStrategy,E> {
         return self.distinctUntilChanged { (lhs, rhs) -> Bool in
             return lhs.value == rhs.value
         }

--- a/Test/OptionalOperatorsTests.swift
+++ b/Test/OptionalOperatorsTests.swift
@@ -59,6 +59,27 @@ class OptionalOperatorsSpec: QuickSpec {
                         .dispose()
                 }
             }
+            
+            context("Signal") {
+                it("unwraps the optional") {
+                    // Check on compile
+                    let _: Signal<Int> = Signal<Int?>
+                        .just(nil)
+                        .filterNil()
+                }
+                
+                it("filters nil values") {
+                    Signal<Int?>
+                        .of(1, nil, 3, 4)
+                        .filterNil()
+                        .asObservable()
+                        .toArray()
+                        .subscribe(onNext: {
+                            expect($0).to(equal([1, 3, 4]))
+                        })
+                        .dispose()
+                }
+            }
         }
 
         describe("Error On Nil") {


### PR DESCRIPTION
Hey!

RxCocoa 4.0 [introduced](https://github.com/ReactiveX/RxSwift/releases/tag/4.0.0-beta.0) Signal - new type of `SharedSequence` that allows modeling of non-replayable events in your app. Current implementation defines Signal as `SharedSequence<SignalSharingStrategy, E>`, similarly to Driver, which is `SharedSequence<DriverSharingStrategy,E>`.

Current RxOptional extensions can only be used with Driver, because they are explicitly restricted to `DriverSharingStrategy`, which makes them unusable on Signal type.

This PR loosens those generic restrictions by changing method return types from `Driver<E>` which is effectively a `SharedSequence<DriverSharingStrategy,E>` to `SharedSequence<SharingStrategy,E>`, which allows all current methods to be used with both Driver and Signal, as well as any other `SharingStrategy` that may be implemented in the future.

This is backwards-compatible change, because it loosens restrictions, and does not impose anything new. 

I've added two tests for Signal type, that show current methods can be used on Signal exactly the same way they are currently used on Driver.