### PR TITLE
Add optional and occupiable methods for `Single`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+- Add optional and occupiable operators to Single trait.
+
 # 3.5.0
 
 - Loosen generic constraints to work with any SharingStrategy, instead of just Driver.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ All operators are also available on `Driver` and `Signal`, unless otherwise note
 ### Optional Operators
 
 ##### filterNil
+Unavailable on `Single`, because `Single`s only emit once.
+
 ```swift
 Observable<String?>
     .of("One", nil, "Three")
@@ -104,6 +106,8 @@ For now the types listed above conform to `Occupiable`. You can also conform
 custom types to `Occupiable`.
 
 ##### filterEmpty
+Unavailable on `Single`, because `Single`s only emit once.
+
 ```swift
 Observable<[String]>
     .of(["Single Element"], [], ["Two", "Elements"])

--- a/RxOptional.xcodeproj/project.pbxproj
+++ b/RxOptional.xcodeproj/project.pbxproj
@@ -69,6 +69,12 @@
 		8482736B1DF9CE3C0083191B /* RxOptionalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983BE1D9035A500409FC8 /* RxOptionalError.swift */; };
 		A9AD4DE9207C6D7E00298702 /* PrimitiveSequence+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9AD4DE8207C6D7E00298702 /* PrimitiveSequence+Optional.swift */; };
 		A9EFF2EE20FDE12E005A3187 /* PrimativeSequence+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EFF2ED20FDE12E005A3187 /* PrimativeSequence+Occupiable.swift */; };
+		A9EFF2F420FE30D0005A3187 /* PrimativeSequence+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EFF2ED20FDE12E005A3187 /* PrimativeSequence+Occupiable.swift */; };
+		A9EFF2F520FE30D0005A3187 /* PrimitiveSequence+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9AD4DE8207C6D7E00298702 /* PrimitiveSequence+Optional.swift */; };
+		A9EFF2F620FE30D1005A3187 /* PrimativeSequence+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EFF2ED20FDE12E005A3187 /* PrimativeSequence+Occupiable.swift */; };
+		A9EFF2F720FE30D1005A3187 /* PrimitiveSequence+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9AD4DE8207C6D7E00298702 /* PrimitiveSequence+Optional.swift */; };
+		A9EFF2F820FE30D1005A3187 /* PrimativeSequence+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EFF2ED20FDE12E005A3187 /* PrimativeSequence+Occupiable.swift */; };
+		A9EFF2F920FE30D1005A3187 /* PrimitiveSequence+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9AD4DE8207C6D7E00298702 /* PrimitiveSequence+Optional.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -642,7 +648,9 @@
 				4B5983C31D9035A500409FC8 /* SharedSequence+Occupiable.swift in Sources */,
 				4B5983D31D9035A500409FC8 /* Occupiable.swift in Sources */,
 				4B5983DB1D9035A500409FC8 /* RxOptionalError.swift in Sources */,
+				A9EFF2F520FE30D0005A3187 /* PrimitiveSequence+Optional.swift in Sources */,
 				4B5983CB1D9035A500409FC8 /* Observable+Occupiable.swift in Sources */,
+				A9EFF2F420FE30D0005A3187 /* PrimativeSequence+Occupiable.swift in Sources */,
 				4B5983CF1D9035A500409FC8 /* Observable+Optional.swift in Sources */,
 				4B5983D71D9035A500409FC8 /* OptionalType.swift in Sources */,
 			);
@@ -656,7 +664,9 @@
 				4B5983C41D9035A500409FC8 /* SharedSequence+Occupiable.swift in Sources */,
 				4B5983D41D9035A500409FC8 /* Occupiable.swift in Sources */,
 				4B5983DC1D9035A500409FC8 /* RxOptionalError.swift in Sources */,
+				A9EFF2F720FE30D1005A3187 /* PrimitiveSequence+Optional.swift in Sources */,
 				4B5983CC1D9035A500409FC8 /* Observable+Occupiable.swift in Sources */,
+				A9EFF2F620FE30D1005A3187 /* PrimativeSequence+Occupiable.swift in Sources */,
 				4B5983D01D9035A500409FC8 /* Observable+Optional.swift in Sources */,
 				4B5983D81D9035A500409FC8 /* OptionalType.swift in Sources */,
 			);
@@ -697,7 +707,9 @@
 				848273671DF9CE3C0083191B /* Observable+Occupiable.swift in Sources */,
 				848273651DF9CE3C0083191B /* SharedSequence+Occupiable.swift in Sources */,
 				8482736A1DF9CE3C0083191B /* OptionalType.swift in Sources */,
+				A9EFF2F920FE30D1005A3187 /* PrimitiveSequence+Optional.swift in Sources */,
 				8482736B1DF9CE3C0083191B /* RxOptionalError.swift in Sources */,
+				A9EFF2F820FE30D1005A3187 /* PrimativeSequence+Occupiable.swift in Sources */,
 				848273681DF9CE3C0083191B /* Observable+Optional.swift in Sources */,
 				848273661DF9CE3C0083191B /* SharedSequence+Optional.swift in Sources */,
 			);

--- a/RxOptional.xcodeproj/project.pbxproj
+++ b/RxOptional.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		848273691DF9CE3C0083191B /* Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983BC1D9035A500409FC8 /* Occupiable.swift */; };
 		8482736A1DF9CE3C0083191B /* OptionalType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983BD1D9035A500409FC8 /* OptionalType.swift */; };
 		8482736B1DF9CE3C0083191B /* RxOptionalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5983BE1D9035A500409FC8 /* RxOptionalError.swift */; };
+		A9AD4DE9207C6D7E00298702 /* PrimitiveSequence+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9AD4DE8207C6D7E00298702 /* PrimitiveSequence+Optional.swift */; };
+		A9EFF2EE20FDE12E005A3187 /* PrimativeSequence+Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EFF2ED20FDE12E005A3187 /* PrimativeSequence+Occupiable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -136,6 +138,8 @@
 		4B5983E81D9035BD00409FC8 /* OccupiableOperatorsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OccupiableOperatorsTests.swift; sourceTree = "<group>"; };
 		4B5983E91D9035BD00409FC8 /* OptionalOperatorsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionalOperatorsTests.swift; sourceTree = "<group>"; };
 		848273561DF9C9660083191B /* RxOptional.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxOptional.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A9AD4DE8207C6D7E00298702 /* PrimitiveSequence+Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrimitiveSequence+Optional.swift"; sourceTree = "<group>"; };
+		A9EFF2ED20FDE12E005A3187 /* PrimativeSequence+Occupiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrimativeSequence+Occupiable.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -272,6 +276,8 @@
 				4B5983B91D9035A500409FC8 /* SharedSequence+Optional.swift */,
 				4B5983BA1D9035A500409FC8 /* Observable+Occupiable.swift */,
 				4B5983BB1D9035A500409FC8 /* Observable+Optional.swift */,
+				A9EFF2ED20FDE12E005A3187 /* PrimativeSequence+Occupiable.swift */,
+				A9AD4DE8207C6D7E00298702 /* PrimitiveSequence+Optional.swift */,
 				4B5983BC1D9035A500409FC8 /* Occupiable.swift */,
 				4B5983BD1D9035A500409FC8 /* OptionalType.swift */,
 				4B5983BE1D9035A500409FC8 /* RxOptionalError.swift */,
@@ -610,7 +616,9 @@
 				4B5983C61D9035A500409FC8 /* SharedSequence+Optional.swift in Sources */,
 				4B5983C21D9035A500409FC8 /* SharedSequence+Occupiable.swift in Sources */,
 				4B5983D21D9035A500409FC8 /* Occupiable.swift in Sources */,
+				A9EFF2EE20FDE12E005A3187 /* PrimativeSequence+Occupiable.swift in Sources */,
 				4B5983DA1D9035A500409FC8 /* RxOptionalError.swift in Sources */,
+				A9AD4DE9207C6D7E00298702 /* PrimitiveSequence+Optional.swift in Sources */,
 				4B5983CA1D9035A500409FC8 /* Observable+Occupiable.swift in Sources */,
 				4B5983CE1D9035A500409FC8 /* Observable+Optional.swift in Sources */,
 				4B5983D61D9035A500409FC8 /* OptionalType.swift in Sources */,

--- a/Source/PrimativeSequence+Occupiable.swift
+++ b/Source/PrimativeSequence+Occupiable.swift
@@ -1,0 +1,40 @@
+import Foundation
+import RxSwift
+
+public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementType: Occupiable {
+    /**
+     Replaces empty occupiable elements with result returned by `handler`.
+     
+     - parameter handler: empty handler throwing function that returns `Single` of non-empty occupiable elements.
+     
+     - returns: `Single` of the source `Single`'s occupiable elements, with empty occupiable elements replaced by the handler's returned non-empty occupiable elements.
+     */
+    
+    public func catchOnEmpty(_ handler: @escaping () throws -> PrimitiveSequence<SingleTrait, ElementType>) -> PrimitiveSequence<SingleTrait, ElementType> {
+        return self.flatMap { element -> PrimitiveSequence<SingleTrait, ElementType> in
+            guard element.isNotEmpty else {
+                return try handler()
+            }
+            return PrimitiveSequence<SingleTrait, ElementType>.just(element)
+        }
+    }
+    
+    /**
+     Throws an error if the source `Single` contains an empty occupiable element; otherwise returns original source `Single` of non-empty occupiable elements.
+     
+     - parameter error: error to throw when an empty occupiable element is encountered. Defaults to `RxOptionalError.EmptyOccupiable`.
+     
+     - throws: `error` if an empty occupiable element is encountered.
+     
+     - returns: original source `Single` of non-empty occupiable elements if it contains no empty occupiable elements.
+     */
+    
+    public func errorOnEmpty(_ error: Error = RxOptionalError.emptyOccupiable(ElementType.self)) -> PrimitiveSequence<SingleTrait, ElementType> {
+        return self.map { element in
+            guard element.isNotEmpty else {
+                throw error
+            }
+            return element
+        }
+    }
+}

--- a/Source/PrimitiveSequence+Optional.swift
+++ b/Source/PrimitiveSequence+Optional.swift
@@ -1,0 +1,57 @@
+import Foundation
+import RxSwift
+
+public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementType: OptionalType {
+    /**
+     Throws an error if the source `Single` contains an empty element; otherwise returns original source `Single` of non-empty elements.
+     
+     - parameter error: error to throw when an empty element is encountered. Defaults to `RxOptionalError.FoundNilWhileUnwrappingOptional`.
+     
+     - throws: `error` if an empty element is encountered.
+     
+     - returns: original source `Single` of non-empty elements if it contains no empty elements.
+     */
+    
+    public func errorOnNil(_ error: Error = RxOptionalError.foundNilWhileUnwrappingOptional(ElementType.self)) -> PrimitiveSequence<SingleTrait, ElementType.Wrapped> {
+        return self.map { element -> ElementType.Wrapped in
+            guard let value = element.value else {
+                throw error
+            }
+            return value
+        }
+    }
+    
+    /**
+     Unwraps optional elements and replaces `nil` elements with `valueOnNil`.
+     
+     - parameter valueOnNil: value to use when `nil` is encountered.
+     
+     - returns: `Single` of the source `Single`'s unwrapped elements, with `nil` elements replaced by `valueOnNil`.
+     */
+    
+    public func replaceNilWith(_ valueOnNil: ElementType.Wrapped) -> PrimitiveSequence<SingleTrait, ElementType.Wrapped> {
+        return self.map { element -> ElementType.Wrapped in
+            guard let value = element.value else {
+                return valueOnNil
+            }
+            return value
+        }
+    }
+    
+    /**
+     Unwraps optional elements and replaces `nil` elements with result returned by `handler`.
+     
+     - parameter handler: `nil` handler throwing function that returns `Single` of non-`nil` elements.
+     
+     - returns: `Single` of the source `Single`'s unwrapped elements, with `nil` elements replaced by the handler's returned non-`nil` elements.
+     */
+    
+    public func catchOnNil(_ handler: @escaping () throws -> PrimitiveSequence<SingleTrait, ElementType.Wrapped>) -> PrimitiveSequence<SingleTrait, ElementType.Wrapped> {
+        return self.flatMap { element -> PrimitiveSequence<SingleTrait, ElementType.Wrapped> in
+            guard let value = element.value else {
+                return try handler()
+            }
+            return PrimitiveSequence<SingleTrait, ElementType.Wrapped>.just(value)
+        }
+    }
+}

--- a/Test/OccupiableOperatorsTests.swift
+++ b/Test/OccupiableOperatorsTests.swift
@@ -101,6 +101,18 @@ class OccupiableOperatorsSpec: QuickSpec {
                     })
                     .dispose()
             }
+            
+            context("Single") {
+                Single<[Int]>
+                    .just([])
+                    .catchOnEmpty {
+                        return Single<[Int]>.just([2])
+                    }
+                    .subscribe(onSuccess: {
+                        expect($0).to(equal([2]))
+                    })
+                    .dispose()
+            }
         }
 
         describe("errorOnEmpty") {
@@ -109,21 +121,40 @@ class OccupiableOperatorsSpec: QuickSpec {
                     .of([1], [], [3, 4], [5])
                     .errorOnEmpty()
                     .toArray()
-                        .subscribe { event in
-                            switch event {
-                            case .next(let element):
-                                expect(element[0]).to(equal([1]))
-                                expect(element[1]).to(equal([3, 4]))
-                                expect(element[2]).to(equal([5]))
-                            case .error(let error):
-                                // FIXME: There should be a better way to do this and to check a more specific error.
-                                expect { throw error }
-                                    .to(throwError(errorType: RxOptionalError.self))
-                            case .completed:
-                                break
-                            }
+                    .subscribe { event in
+                        switch event {
+                        case .next(let element):
+                            expect(element[0]).to(equal([1]))
+                            expect(element[1]).to(equal([3, 4]))
+                            expect(element[2]).to(equal([5]))
+                        case .error(let error):
+                            // FIXME: There should be a better way to do this and to check a more specific error.
+                            expect { throw error }
+                                .to(throwError(errorType: RxOptionalError.self))
+                        case .completed:
+                            break
                         }
-                        .dispose()
+                    }
+                    .dispose()
+            }
+            
+            context("Single") {
+                Single<[Int]>
+                    .just([])
+                    .catchOnEmpty {
+                        return Single<[Int]>.just([2])
+                    }
+                    .subscribe { event in
+                        switch event {
+                        case .success:
+                            break
+                        case .error(let error):
+                            // FIXME: There should be a better way to do this and to check a more specific error.
+                            expect { throw error }
+                                .to(throwError(errorType: RxOptionalError.self))
+                        }
+                    }
+                    .dispose()
             }
         }
     }

--- a/Test/OptionalOperatorsTests.swift
+++ b/Test/OptionalOperatorsTests.swift
@@ -111,6 +111,32 @@ class OptionalOperatorsSpec: QuickSpec {
                         .dispose()
                 }
             }
+            
+            context("Single") {
+                it("unwraps the optional") {
+                    // Check on compile
+                    let _: Single<Int> = Single<Int?>
+                        .just(nil)
+                        .errorOnNil()
+                }
+                
+                it("throws default error") {
+                    Single<Int?>
+                        .just(nil)
+                        .errorOnNil()
+                        .subscribe { event in
+                            switch event {
+                            case .success:
+                                break
+                            case .error(let error):
+                                // FIXME: There should be a better way to do this and to check a more specific error.
+                                expect { throw error }
+                                    .to(throwError(errorType: RxOptionalError.self))
+                            }
+                        }
+                        .dispose()
+                }
+            }
         }
 
         describe("replaceNilWith") {
@@ -150,6 +176,25 @@ class OptionalOperatorsSpec: QuickSpec {
                         .toArray()
                         .subscribe(onNext: {
                             expect($0).to(equal([1, 2, 3, 4]))
+                        })
+                        .dispose()
+                }
+            }
+            
+            context("Single") {
+                it("unwraps the optional") {
+                    // Check on compile
+                    let _: Single<Int> = Single<Int?>
+                        .just(nil)
+                        .replaceNilWith(0)
+                }
+                
+                it("replaces nil values") {
+                    Single<Int?>
+                        .just(nil)
+                        .replaceNilWith(2)
+                        .subscribe(onSuccess: {
+                            expect($0).to(equal(2))
                         })
                         .dispose()
                 }
@@ -201,6 +246,29 @@ class OptionalOperatorsSpec: QuickSpec {
                         .toArray()
                         .subscribe(onNext: {
                             expect($0).to(equal([1, 2, 3, 4]))
+                        })
+                        .dispose()
+                }
+            }
+            
+            context("Single") {
+                it("unwraps the optional") {
+                    // Check on compile
+                    let _: Single<Int> = Single<Int?>
+                        .just(nil)
+                        .catchOnNil {
+                            return Single<Int>.just(0)
+                        }
+                }
+                
+                it("catches nil and continues with new observable") {
+                    Single<Int?>
+                        .just(nil)
+                        .catchOnNil {
+                            return Single<Int>.just(2)
+                        }
+                        .subscribe(onSuccess: {
+                            expect($0).to(equal(2))
                         })
                         .dispose()
                 }


### PR DESCRIPTION
Hello.

This PR adds optional / occupiable operators for Single. Wish this can help person have similar repeated code with me.

In my case, as common usage of `Single`, I made common request method to return `Single` with optional element type. Only few case allows empty response but general method set to return optional type. In this circumstance, `asObservable().errorOnNil().asSingle()` was repeatedly used.