### PR TITLE
Make Optional conform to Occupiable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 
 - Update WatchOS deployment target to 3.0.
+- Optional now conforms to Occupiable, which means you can call `isEmpty` and `isNotEmpty` directly on optional values.
 
 # 3.6.2
 

--- a/Source/Occupiable.swift
+++ b/Source/Occupiable.swift
@@ -20,3 +20,14 @@ extension String: Occupiable { }
 extension Array: Occupiable { }
 extension Dictionary: Occupiable { }
 extension Set: Occupiable { }
+
+extension Optional: Occupiable where Wrapped: Occupiable {
+    public var isEmpty: Bool {
+        switch self {
+        case .none:
+            return true
+        case .some(let value):
+            return value.isEmpty
+        }
+    }
+}


### PR DESCRIPTION
This change allows you directly call `isEmpty` and `isNotEmpty` on optional values.