### PR TITLE
Simplify Occupiable to target all types that conform to Collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 
 - Update WatchOS deployment target to 3.0.
+- Simplified the `Occupiable` conformances to target _all_ types that conform to `Collection`.
 
 # 3.6.2
 

--- a/Source/Occupiable.swift
+++ b/Source/Occupiable.swift
@@ -15,8 +15,4 @@ public extension Occupiable {
     }
 }
 
-extension String: Occupiable { }
-// I can't think of a way to combine these collection types. Suggestions welcomed!
-extension Array: Occupiable { }
-extension Dictionary: Occupiable { }
-extension Set: Occupiable { }
+extension Collection: Occupiable { }


### PR DESCRIPTION
All of the named types that had declared conformance to `Occupiable`  (`String`, `Array`, `Dictionary` and `Set`) were derived from `Collection`, which is where the `isEmpty` property sources from. 

This change will allow `isNotEmpty` to work in more situations.