### PR TITLE
Remove the redundant public access modifiers on already public extensions

### DIFF
--- a/Source/Observable+Occupiable.swift
+++ b/Source/Observable+Occupiable.swift
@@ -8,7 +8,7 @@ public extension ObservableType where E: Occupiable {
      - returns: `Observable` of source `Observable`'s occupiable elements, with empty occupiable elements filtered out.
      */
     
-    public func filterEmpty() -> Observable<E> {
+    func filterEmpty() -> Observable<E> {
         return self.flatMap { element -> Observable<E> in
             guard element.isNotEmpty else {
                 return Observable<E>.empty()
@@ -25,7 +25,7 @@ public extension ObservableType where E: Occupiable {
      - returns: `Observable` of the source `Observable`'s occupiable elements, with empty occupiable elements replaced by the handler's returned non-empty occupiable elements.
      */
     
-    public func catchOnEmpty(_ handler: @escaping () throws -> Observable<E>) -> Observable<E> {
+    func catchOnEmpty(_ handler: @escaping () throws -> Observable<E>) -> Observable<E> {
         return self.flatMap { element -> Observable<E> in
             guard element.isNotEmpty else {
                 return try handler()
@@ -44,7 +44,7 @@ public extension ObservableType where E: Occupiable {
      - returns: original source `Observable` of non-empty occupiable elements if it contains no empty occupiable elements.
      */
     
-    public func errorOnEmpty(_ error: Error = RxOptionalError.emptyOccupiable(E.self)) -> Observable<E> {
+    func errorOnEmpty(_ error: Error = RxOptionalError.emptyOccupiable(E.self)) -> Observable<E> {
         return self.map { element in
             guard element.isNotEmpty else {
                 throw error

--- a/Source/Observable+Optional.swift
+++ b/Source/Observable+Optional.swift
@@ -11,7 +11,7 @@ public extension ObservableType where E: OptionalType {
      - returns: `Observable` of source `Observable`'s elements, with `nil` elements filtered out.
      */
     
-    public func filterNil() -> Observable<E.Wrapped> {
+    func filterNil() -> Observable<E.Wrapped> {
         return self.flatMap { element -> Observable<E.Wrapped> in
             guard let value = element.value else {
                 return Observable<E.Wrapped>.empty()
@@ -28,7 +28,7 @@ public extension ObservableType where E: OptionalType {
     - returns: `Observable` of source `Observable`'s elements, with `nil` elements filtered out.
     */
 
-    public func filterNilKeepOptional() -> Observable<E> {
+    func filterNilKeepOptional() -> Observable<E> {
         return self.filter { element -> Bool in
             return element.value != nil
         }
@@ -44,7 +44,7 @@ public extension ObservableType where E: OptionalType {
      - returns: original source `Observable` of non-empty elements if it contains no empty elements.
      */
     
-    public func errorOnNil(_ error: Error = RxOptionalError.foundNilWhileUnwrappingOptional(E.self)) -> Observable<E.Wrapped> {
+    func errorOnNil(_ error: Error = RxOptionalError.foundNilWhileUnwrappingOptional(E.self)) -> Observable<E.Wrapped> {
         return self.map { element -> E.Wrapped in
             guard let value = element.value else {
                 throw error
@@ -61,7 +61,7 @@ public extension ObservableType where E: OptionalType {
      - returns: `Observable` of the source `Observable`'s unwrapped elements, with `nil` elements replaced by `valueOnNil`.
      */
     
-    public func replaceNilWith(_ valueOnNil: E.Wrapped) -> Observable<E.Wrapped> {
+    func replaceNilWith(_ valueOnNil: E.Wrapped) -> Observable<E.Wrapped> {
         return self.map { element -> E.Wrapped in
             guard let value = element.value else {
                 return valueOnNil
@@ -78,7 +78,7 @@ public extension ObservableType where E: OptionalType {
      - returns: `Observable` of the source `Observable`'s unwrapped elements, with `nil` elements replaced by the handler's returned non-`nil` elements.
      */
     
-    public func catchOnNil(_ handler: @escaping () throws -> Observable<E.Wrapped>) -> Observable<E.Wrapped> {
+    func catchOnNil(_ handler: @escaping () throws -> Observable<E.Wrapped>) -> Observable<E.Wrapped> {
         return self.flatMap { element -> Observable<E.Wrapped> in
             guard let value = element.value else {
                 return try handler()
@@ -98,7 +98,7 @@ public extension ObservableType where E: OptionalType, E.Wrapped: Equatable {
      - returns: An observable sequence only containing the distinct contiguous elements, based on equality operator, from the source sequence.
      */
     
-    public func distinctUntilChanged() -> Observable<Self.E> {
+    func distinctUntilChanged() -> Observable<Self.E> {
         return self.distinctUntilChanged { (lhs, rhs) -> Bool in
             return lhs.value == rhs.value
         }

--- a/Source/Occupiable.swift
+++ b/Source/Occupiable.swift
@@ -10,7 +10,7 @@ public protocol Occupiable {
 }
 
 public extension Occupiable {
-    public var isNotEmpty: Bool {
+    var isNotEmpty: Bool {
         return !isEmpty
     }
 }

--- a/Source/SharedSequence+Occupiable.swift
+++ b/Source/SharedSequence+Occupiable.swift
@@ -8,7 +8,7 @@ public extension SharedSequenceConvertibleType where E: Occupiable {
      - returns: `Driver` of source `Driver`'s elements, with empty elements filtered out.
      */
     
-    public func filterEmpty() -> SharedSequence<SharingStrategy,E> {
+    func filterEmpty() -> SharedSequence<SharingStrategy,E> {
         return flatMap { element -> SharedSequence<SharingStrategy,E> in
             guard element.isNotEmpty else {
                 return SharedSequence<SharingStrategy,E>.empty()
@@ -25,7 +25,7 @@ public extension SharedSequenceConvertibleType where E: Occupiable {
      - returns: `Driver` of the source `Driver`'s elements, with empty elements replaced by the handler's returned non-empty elements.
      */
     
-    public func catchOnEmpty(_ handler: @escaping () -> SharedSequence<SharingStrategy,E>) -> SharedSequence<SharingStrategy,E> {
+    func catchOnEmpty(_ handler: @escaping () -> SharedSequence<SharingStrategy,E>) -> SharedSequence<SharingStrategy,E> {
         return flatMap { element -> SharedSequence<SharingStrategy,E> in
             guard element.isNotEmpty else {
                 return handler()

--- a/Source/SharedSequence+Optional.swift
+++ b/Source/SharedSequence+Optional.swift
@@ -7,7 +7,7 @@ public extension SharedSequenceConvertibleType where E: OptionalType {
      - returns: `Driver` of source `Driver`'s elements, with `nil` elements filtered out.
      */
     
-    public func filterNil() -> SharedSequence<SharingStrategy,E.Wrapped> {
+    func filterNil() -> SharedSequence<SharingStrategy,E.Wrapped> {
         return flatMap { element -> SharedSequence<SharingStrategy,E.Wrapped> in
             guard let value = element.value else {
                 return SharedSequence<SharingStrategy,E.Wrapped>.empty()
@@ -24,7 +24,7 @@ public extension SharedSequenceConvertibleType where E: OptionalType {
      - returns: `Driver` of the source `Driver`'s unwrapped elements, with `nil` elements replaced by `valueOnNil`.
      */
     
-    public func replaceNilWith(_ valueOnNil: E.Wrapped) -> SharedSequence<SharingStrategy,E.Wrapped> {
+    func replaceNilWith(_ valueOnNil: E.Wrapped) -> SharedSequence<SharingStrategy,E.Wrapped> {
         return map { element -> E.Wrapped in
             guard let value = element.value else {
                 return valueOnNil
@@ -41,7 +41,7 @@ public extension SharedSequenceConvertibleType where E: OptionalType {
      - returns: `Driver` of the source `Driver`'s unwrapped elements, with `nil` elements replaced by the handler's returned non-`nil` elements.
      */
     
-    public func catchOnNil(_ handler: @escaping () -> SharedSequence<SharingStrategy,E.Wrapped>) -> SharedSequence<SharingStrategy,E.Wrapped> {
+    func catchOnNil(_ handler: @escaping () -> SharedSequence<SharingStrategy,E.Wrapped>) -> SharedSequence<SharingStrategy,E.Wrapped> {
         return flatMap { element -> SharedSequence<SharingStrategy,E.Wrapped> in
             guard let value = element.value else {
                 return handler()
@@ -61,7 +61,7 @@ public extension SharedSequenceConvertibleType where E: OptionalType, E.Wrapped:
      - returns: An observable sequence only containing the distinct contiguous elements, based on equality operator, from the source sequence.
      */
     
-    public func distinctUntilChanged() -> SharedSequence<SharingStrategy,E> {
+    func distinctUntilChanged() -> SharedSequence<SharingStrategy,E> {
         return self.distinctUntilChanged { (lhs, rhs) -> Bool in
             return lhs.value == rhs.value
         }


### PR DESCRIPTION
The Swift 5.0 compiler shipped with Xcode 10.2 produces warnings when you declare methods and properties within already `public` extensions. This PR removes those redundant declarations - this change should be backwards compatible with Swift 4.2.