### PR TITLE
Add `filterNil` function with transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ next(Three)
 completed
 ```
 
+```swift
+Observable<String>
+    .of("1", "lee", "3")
+    .filterNil { Int($0) }
+    // Type is now Observable<Int>
+    .subscribe { print($0) }
+```
+
+```text
+next(1)
+next(3)
+completed
+```
+
 ##### replaceNilWith
 
 ```swift

--- a/Sources/RxOptional/Observable+Optional.swift
+++ b/Sources/RxOptional/Observable+Optional.swift
@@ -88,6 +88,19 @@ public extension ObservableType where Element: OptionalType {
     }
 }
 
+public extension ObservableType {
+    /**
+    Unwraps and filters out `nil` result returned by `transform`
+    
+    - parameter transform: A transform function to apply to each source element.
+    
+    - returns: `Observable` of source `transform` result, with `nil` elements filtered out.
+    */
+    func filterNil<Value>(_ transform: @escaping (Element) throws -> Value?) -> Observable<Value> {
+        return self.map(transform).filterNil()
+    }
+}
+
 #if !swift(>=3.3) || (swift(>=4.0) && !swift(>=4.1))
 public extension ObservableType where Element: OptionalType, Element.Wrapped: Equatable {
     /**

--- a/Sources/RxOptional/SharedSequence+Optional.swift
+++ b/Sources/RxOptional/SharedSequence+Optional.swift
@@ -51,6 +51,20 @@ public extension SharedSequenceConvertibleType where Element: OptionalType {
     }
 }
 
+public extension SharedSequenceConvertibleType {
+    /**
+     Unwraps and filters out `nil` result returned by `transform`
+     
+     - parameter transform: A transform function to apply to each source element.
+     
+     - returns: `Driver` of source `transform` result, with `nil` elements filtered out.
+     */
+    
+    func filterNil<Value>(_ transform: @escaping (Element) -> Value?) -> SharedSequence<SharingStrategy, Value> {
+        return self.map(transform).filterNil()
+    }
+}
+
 #if !swift(>=3.3) || (swift(>=4.0) && !swift(>=4.1))
 public extension SharedSequenceConvertibleType where Element: OptionalType, Element.Wrapped: Equatable {
     /**


### PR DESCRIPTION
Hello. I wanted to add `filterNil` function
The new `filterNil` function receive a `{ (Element) -> Value? }` closure and filters out `nil` result
The following code listing shown a simple example
```swift
Observable<String>
    .of("1", "lee", "3")
    .filterNil { Int($0) }
    // Type is now Observable<Int>
    .subscribe { print($0) }
```

```swift
let o = Observable<Result<String, Error>>

let success = o
    .filterNil { result in
        guard case .success(let value) = result else {
            return nil
        }
        return value
    }
    // Type is now Observable<String>
    .subscribe { print($0) }
```

Before apply this PR, we solved combination of 'map' and 'filterNil' operator and it was not **swifty**
But now, we will be able to write **swifty** code using the newly added 'filterNil'.