### PR TITLE
fix: stop tracking Swift package manager xcworkspace

### DIFF
--- a/RxOptional-SPM.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/RxOptional-SPM.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>


### PR DESCRIPTION
Fixes https://github.com/RxSwiftCommunity/RxOptional/issues/91

RxOptional-SPM.xcodeproj should be generated by CI only and not tracked in the repo.

In order for Carthage to successfully build this project there can't be any xcodeproj's without a project.pbxproj file. The parent RxOptional-SPM.xcodeproj is in the .gitignore however the contents.xcworkspacedata is tracked in this repository so the xcodeproj is still being included.


