### PR TITLE
Upgrade minimum Swift version for SPM to 5.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -25,7 +25,10 @@ let package = Package(name: "RxOptional",
                       targets: [
                         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
                         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-                        .target(name: "RxOptional", dependencies: ["RxSwift", "RxCocoa"],
+                        .target(name: "RxOptional", dependencies: [
+                          .product(name: "RxSwift", package: "RxSwift"),
+                          .product(name: "RxCocoa", package: "RxSwift")
+                        ],
                                 path: "Sources"),
                         .testTarget(name: "RxOptionalTests", dependencies: ["RxOptional", "Quick", "Nimble"]) // dev
                       ],


### PR DESCRIPTION
If a Swift Package defines its Swift toolchain version prior to 5.2, consumers will get extra test dependencies fetched, which is not needed at all.

This PR updates SPM toolchain version up to 5.2 to solve is issue.

Before:
<img width="320" alt="截屏2021-08-26 下午4 34 04" src="https://user-images.githubusercontent.com/8158163/130929996-a844fdf4-365a-443f-bbd0-8b8f54b29105.png">

After:
<img width="320" alt="截屏2021-08-26 下午4 35 05" src="https://user-images.githubusercontent.com/8158163/130930101-c64514c9-9da4-452b-a0d9-1c4d42982e80.png">
