### PR TITLE
Remove email from LICENSE. Match LICENSE.md to LICENSE.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Thane Gill <me@thanegill.com>
+Copyright (c) 2016 Thane Gill
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Junior B.
+Copyright (c) 2016 Thane Gill
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
For the past 6 or so year, I have received hundred of emails from desperate Uber users and drivers, as my email is the only email in the iOS Software License Acknowledgements page. I'd like that to stop.

@RxSwiftCommunity/contributors Can someone help me make a new release with these changes? And if anyone knows any iOS Engineers at Uber, I would deeply appreciate you passing on a request to update to the new RXOptional release with my email removed. Thank you in advance!
